### PR TITLE
install.mdx: CORS header appears to work for browser custom repos.

### DIFF
--- a/src/content/docs/using/install.mdx
+++ b/src/content/docs/using/install.mdx
@@ -122,7 +122,7 @@ moonlight can be installed as a browser extension. To use it, [manually build mo
 The output extension will be at `dist/browser`. Chrome users can check "Developer mode" and click "Load unpacked" in `chrome://extensions`, and Firefox users can click "Load Temporary Add-on" in `about:debugging`.
 
 :::caution
-Browser support is experimental and may be unreliable. Developing extensions or using custom repositories is not supported with the browser extension.
+Browser support is experimental and may be unreliable. Developing extensions from a local directory is not supported with the browser extension, and custom repositories may run into CORS issues (i.e. if their servers do not set `Access-Control-Allow-Origin: *`).
 :::
 
 ## Nix


### PR DESCRIPTION
_For verification only,_ you may see: 20kdc.duckdns.org [slash] big [slash] moonlight [slash] repo.json

This was tested on an ungoogled-chromium with Moonlight installed from a CI build. Further testing appreciated.

Assuming this works reliably, there's, perhaps, the possibility here of a 'proper' browser extension development setup using a local web server.

I also wanted to look into the possibility of using the [File System API](https://developer.mozilla.org/en-US/docs/Web/API/Window/showDirectoryPicker), but that's not likely to be possible, as the handle will almost certainly be lost on refresh.